### PR TITLE
use dbcidp instead of fors

### DIFF
--- a/includes/heimdalCurl.inc
+++ b/includes/heimdalCurl.inc
@@ -23,26 +23,8 @@ class HeimdalCurl extends MicroCURL {
 
       $attributes = $this->get();
 
-      /* THIS IS TEMPORARY UNTIL HEIMDAL HAS REPLACED FORS WITH IDP */
       $decoded_att = json_decode($attributes);
 
-      if (isset($decoded_att->attributes)) {
-        if (!isset($decoded_att->attributes->dbcidp)) {
-          // DBCIDP is not present, we need to call IDP to get the rights
-          $rights = idp_autorize_token('netpunkt', $bearer);
-          if (isset($decoded_att->attributes->forsrights)) {
-            unset($decoded_att->attributes->forsrights);
-          }
-          if (isset($rights['rights'])) {
-            $decoded_att->attributes->dbcidp[0]->rights = $rights;
-          }
-        } else {
-          if (isset($decoded_att->attributes->forsrights)) {
-            unset($decoded_att->attributes->forsrights);
-          }
-        }
-      }
-      /* END OF: THIS IS TEMPORARY UNTIL HEIMDAL HAS REPLACED FORS WITH IDP */
       return json_encode($decoded_att);
     }
 

--- a/includes/heimdalHelpers.inc
+++ b/includes/heimdalHelpers.inc
@@ -41,7 +41,7 @@ class HeimdalHelpers {
         $redirect = '&redirect_uri=' . $redirect_url;
       }
       if ($access_platform) {
-        $heimdal_url .= $config['heimdal_client_url'] . 'oauth/authorize?response_type=code&client_id=' . $config['heimdal_client_id'] . $redirect . '&idp=netpunkt';
+        $heimdal_url .= $config['heimdal_client_url'] . 'oauth/authorize?response_type=code&client_id=' . $config['heimdal_client_id'] . $redirect . '&idp=dbcidp';
       }
 
       return $heimdal_url;


### PR DESCRIPTION
Vi skal nu kun bruge IDP (ellers fejler det efter den seneste rettelse i adgangsplatformen, så den ikke bruger FORS til authenticate).